### PR TITLE
Add an option to disable automatic page switching on Bar1

### DIFF
--- a/KkthnxUI/Config/Settings.lua
+++ b/KkthnxUI/Config/Settings.lua
@@ -14,6 +14,7 @@ C["ActionBar"] = {
 	["OutOfMana"] = {0.5, 0.5, 1.0},
 	["OutOfRange"] = {0.8, 0.1, 0.1},
 	["PetBarHide"] = false,
+	["DisableStancePages"] = false,
 	["PetBarHorizontal"] = false,
 	["PetBarMouseover"] = false,
 	["RightBars"] = 1,

--- a/KkthnxUI/Modules/ActionBars/Bar1.lua
+++ b/KkthnxUI/Modules/ActionBars/Bar1.lua
@@ -42,7 +42,10 @@ local Page = {
 local function GetBar(self, defaultPage)
 	local condition = Page["DEFAULT"]
 	local class = K.Class
-	local page = Page[class]
+ 
+	if not C["DisableStancePages"] then
+		local page = Page[class]
+	end
 
 	if not condition then condition = "" end
 

--- a/KkthnxUI_Config/KkthnxUI_Config.lua
+++ b/KkthnxUI_Config/KkthnxUI_Config.lua
@@ -87,6 +87,7 @@ KkthnxUIConfig.ColorDefaults = {
 	["ActionBar"] = {
 		["OutOfMana"] = {0.5, 0.5, 1.0},
 		["OutOfRange"] = {0.8, 0.1, 0.1},
+		["DisableStancePages"] = false,
 	},
 	-- General
 	["General"] = {

--- a/KkthnxUI_Config/Locales/deDE.lua
+++ b/KkthnxUI_Config/Locales/deDE.lua
@@ -306,6 +306,11 @@ KkthnxUIConfig["deDE"] = {
 			["Desc"] = "Hide pet bar",
 		},
 
+		["DisableStancePages"] = {
+			["Name"] = "Deaktiviere Haltungs-Seiten",
+			["Desc"] = "Deaktiviere das automatische Umschalten der Leistenseite bei Haltungsweches. (Betrifft nur Schurken und Druiden, keine Auswirkungen bei anderen Klassen)",
+		},
+
 		["PetBarHorizontal"] = {
 			["Name"] = "Petbar Horizontal",
 			["Desc"] = "Enable horizontal pet bar",
@@ -355,6 +360,7 @@ KkthnxUIConfig["deDE"] = {
 			["Name"] = "Auto Add New Spells",
 			["Desc"] = "Auto add new learned spells to the actionbar. (This is needed for some quests)",
 		},
+
 	},
 
 	-- Nameplates Local

--- a/KkthnxUI_Config/Locales/enUS.lua
+++ b/KkthnxUI_Config/Locales/enUS.lua
@@ -301,6 +301,11 @@ KkthnxUIConfig["enUS"] = {
 			["Desc"] = "Hide pet bar",
 		},
 
+		["DisableStancePages"] = {
+			["Name"] = "Disable Stance Pages",
+			["Desc"] = "Disables automatic page-switching depending on the players stance. (Only affects rogues and druids, has no effect on other classes)",
+		},
+
 		["PetBarHorizontal"] = {
 			["Name"] = "Petbar Horizontal",
 			["Desc"] = "Enable horizontal pet bar",
@@ -350,6 +355,7 @@ KkthnxUIConfig["enUS"] = {
 			["Name"] = "Auto Add New Spells",
 			["Desc"] = "Auto add new learned spells to the actionbar. (This is needed for some quests)",
 		},
+
 	},
 
 	-- Nameplates Local


### PR DESCRIPTION
Usefull for rogues and druids if they dont want the page switching.

## Proposed Changes

  - Added configuration option to disable the page switching (default is with stance switching ofc)
  - Modified Bar1 to use the configuration option

@Kkthnx-WoW
