### PR TITLE
Fix for zero width movers

### DIFF
--- a/KkthnxUI/Core/Movers.lua
+++ b/KkthnxUI/Core/Movers.lua
@@ -20,6 +20,8 @@ Movers:RegisterEvent("PLAYER_REGEN_DISABLED")
 Movers.Frames = {}
 Movers.Defaults = {}
 
+local SizeReferenceFrames = {}
+
 local classColor = K.Class == "PRIEST" and K.PriestColors or (CUSTOM_CLASS_COLORS and CUSTOM_CLASS_COLORS[K.Class] or RAID_CLASS_COLORS[K.Class])
 
 local function SetModifiedBackdrop(self)
@@ -31,6 +33,77 @@ local function SetOriginalBackdrop(self)
 	if self.Backdrop then self = self.Backdrop end
 	self:SetBackdropColor(C["Media"].BackdropColor[1], C["Media"].BackdropColor[2], C["Media"].BackdropColor[3], C["Media"].BackdropColor[4])
 end
+
+-- Generate a human readable name without prefixes
+local function GenerateName(name)
+	return name and name:gsub("^oUF_",""):gsub("^KkthnxUI_",""):gsub("^KkthnxUI",""):gsub("^Kkthnx_",""):gsub("^Kkthnx","") or UNKNOWNOBJECT
+end 
+
+-- Generate a proper on-screen point depending on which part of the screen it is in, 
+-- also taking the frame size into consideration. 
+local function GeneratePoints(frame)
+	local width, height = GetScreenWidth(), GetScreenHeight() -- screen size
+	local w, h = frame:GetSize() -- frame size
+
+	-- Center point relative to the bottom left corner of the screen
+	-- By using this as a reference, frame size (or the lack of) won't affect positioning!
+	local centerX, centerY = frame:GetCenter() 
+	
+	-- Split the screen into 3x3 areas, 
+	-- and create different points based on that.
+	local point, x, y
+
+	-- left side of the screen
+	if centerX < width/3 then 
+		if centerY > height*2/3 then 
+			point = "TOPLEFT"
+			x = centerX
+			y = centerY - height
+		elseif centerY < height/3 then 
+			point = "BOTTOMLEFT"
+			x = centerX
+			y = centerY
+		else 
+			point = "LEFT"
+			x = centerX
+			y = centerY - height/2
+		end 
+
+	-- right side of the screen 
+	elseif centerX > width*2/3 then 
+		if centerY > height*2/3 then 
+			point = "TOPRIGHT"
+			x = centerX - width
+			y = centerY - height
+		elseif centerY < height/3 then 
+			point = "BOTTOMRIGHT"
+			x = centerX - width
+			y = centerY
+		else 
+			point = "RIGHT"
+			x = centerX - width
+			y = centerY - height/2
+		end 
+
+	-- center of the screen
+	else 
+		if centerY > height*2/3 then 
+			point = "TOP"
+			x = centerX - width/2
+			y = centerY - height
+		elseif centerY < height/3 then 
+			point = "BOTTOM"
+			x = centerX - width/2
+			y = centerY
+		else 
+			point = "CENTER"
+			x = centerX - width/2
+			y = centerY - height/2
+		end 
+	end 
+
+	return "CENTER", UIParent, point, x, y
+end 
 
 function Movers:SaveDefaults(frame, a1, p, a2, x, y)
 	if not a1 then
@@ -60,16 +133,28 @@ function Movers:RestoreDefaults(button)
 		Frame:ClearAllPoints()
 		Frame:SetPoint(Anchor1, Parent, Anchor2, X, Y)
 
-		Frame.DragInfo:ClearAllPoints()
-		Frame.DragInfo:SetAllPoints(Frame)
+		if SizeReferenceFrames[Frame] and (Frame:GetWidth() < 1 or Frame:GetHeight() < 1) then 
+			Frame.DragInfo:SetSize(SizeReferenceFrames[Frame]:GetSize())
+			Frame.DragInfo:ClearAllPoints()
+			Frame.DragInfo:SetPoint(Anchor1, Frame, Anchor1, 0, 0)
+		else
+			Frame.DragInfo:ClearAllPoints()
+			Frame.DragInfo:SetAllPoints(Frame)
+		end 
 
 		-- Delete Saved Variable
 		SavedVariables[FrameName] = nil
 	end
 end
 
-function Movers:RegisterFrame(frame)
+function Movers:RegisterFrame(frame, referenceFrame)
 	local Anchor1, Parent, Anchor2, X, Y = frame:GetPoint()
+
+	-- If this is a frame that sometimes has a zero width or height, 
+	-- and thus require another frame to reference its mover size by. 
+	if referenceFrame then 
+		SizeReferenceFrames[frame] = referenceFrame
+	end 
 
 	table_insert(self.Frames, frame)
 
@@ -84,16 +169,12 @@ function Movers:OnDragStop()
 	self:StopMovingOrSizing()
 
 	local Data = KkthnxUIData[Realm][Name].Movers
-	local Anchor1, Parent, Anchor2, X, Y = self:GetPoint()
+	local Anchor1, Parent, Anchor2, X, Y = GeneratePoints(self)
 	local FrameName = self.Parent:GetName()
 	local Frame = self.Parent
 
 	Frame:ClearAllPoints()
 	Frame:SetPoint(Anchor1, Parent, Anchor2, X, Y)
-
-	if not Parent then
-		Parent = UIParent
-	end
 
 	Data[FrameName] = {Anchor1, Parent:GetName(), Anchor2, X, Y}
 end
@@ -104,7 +185,7 @@ function Movers:CreateDragInfo()
 	self.DragInfo:SetTemplate("Transparent")
 	self.DragInfo:SetBackdropBorderColor(72/255, 133/255, 237/255)
 	self.DragInfo:FontString("Text", C["Media"].Font, 12)
-	self.DragInfo.Text:SetText(self:GetName())
+	self.DragInfo.Text:SetText(GenerateName(self:GetName()))
 	self.DragInfo.Text:SetPoint("CENTER")
 	self.DragInfo.Text:SetTextColor(72/255, 133/255, 237/255)
 	self.DragInfo:SetFrameLevel(100)
@@ -157,12 +238,20 @@ function Movers:StartOrStopMoving()
 				Frame.DragInfo:SetFrameStrata("HIGH")
 			end
 
-			if Frame.DragInfo:GetHeight() < 12 then
-				Frame.DragInfo:ClearAllPoints()
-				Frame.DragInfo:SetWidth(Frame:GetWidth())
-				Frame.DragInfo:SetHeight(12)
-				Frame.DragInfo:SetPoint("TOP", Frame)
-			end
+			if SizeReferenceFrames[Frame] and (Frame:GetWidth() < 1 or Frame:GetHeight() < 1) then 
+				local Data = KkthnxUIData[Realm][Name].Movers
+				local Position = Data and Data[Frame:GetName()]
+				if (not Position) then 
+					Data = Movers.Defaults
+					Position = Data and Data[Frame:GetName()]
+				end 
+				if Position then 
+					local Anchor1, Parent, Anchor2, X, Y = unpack(Position)
+					Frame.DragInfo:ClearAllPoints()
+					Frame.DragInfo:SetPoint(Anchor1, _G[Parent], Anchor2, X, Y)
+					Frame.DragInfo:SetSize(SizeReferenceFrames[Frame]:GetSize())
+				end 
+			end 
 		else
 			if Frame.unit then
 				Frame.unit = Frame.oldunit

--- a/KkthnxUI/Modules/UnitFrames/Core.lua
+++ b/KkthnxUI/Modules/UnitFrames/Core.lua
@@ -131,10 +131,13 @@ function Module:GetHealerRaidFramesAttributes()
 		"columnAnchorPoint", "LEFT")
 		if i == 1 then
 			RaidHealer:SetPoint("TOPLEFT", oUF_Player, "BOTTOMRIGHT", 11, -12)
+			Movers:RegisterFrame(RaidHealer)
 		else
-			RaidHealer:SetPoint("TOPLEFT", Raid[i-1], "BOTTOMLEFT", 0, -7)
+			-- Changing this to use CENTER for its own anchoring point, 
+			-- to avoid headers with no units and zero width being positioned wrongly.
+			RaidHealer:SetPoint("CENTER", Raid[i-1], "CENTER", 0, -(7 + 26))
 		end
-		Movers:RegisterFrame(RaidHealer)
+		Movers:RegisterFrame(RaidHealer, i > 1 and Raid[1])
 		Raid[i] = RaidHealer
 	end
 end


### PR DESCRIPTION
Fix to solve the issue where movers would get zero width and sometimes wrong positioning when their frames were unit frame group headers with no active units and zero width.