### PR TITLE
Update QuestNotifier.lua

### DIFF
--- a/KkthnxUI/Modules/Chat/QuickJoin.lua
+++ b/KkthnxUI/Modules/Chat/QuickJoin.lua
@@ -37,7 +37,7 @@ function Module:SocialQueueIsLeader(playerName, leaderName)
 					if (gameClient == BNET_CLIENT_WOW) and (accountName == playerName) then
 						playerName = gameCharacterName
 						if realmName ~= K.Realm then
-							playerName = string_formatformat("%s-%s", playerName, gsub(realmName,"[%s%-]",""))
+							playerName = string_format("%s-%s", playerName, gsub(realmName,"[%s%-]",""))
 						end
 						if leaderName == playerName then
 							return true

--- a/KkthnxUI/Modules/Miscellaneous/QuestNotifier.lua
+++ b/KkthnxUI/Modules/Miscellaneous/QuestNotifier.lua
@@ -133,8 +133,8 @@ function Module:CreateQuestNotifier()
 	end
 
 	FindQuestComplete()
-	self:RegisterEvent("QUEST_ACCEPTED", FindQuestAccept)
-	self:RegisterEvent("QUEST_LOG_UPDATE", FindQuestComplete)
-	self:RegisterEvent("QUEST_TURNED_IN", FindWorldQuestComplete)
-	self:RegisterEvent("UI_INFO_MESSAGE", FindQuestProgress)
+	K:RegisterEvent("QUEST_ACCEPTED", FindQuestAccept)
+	K:RegisterEvent("QUEST_LOG_UPDATE", FindQuestComplete)
+	K:RegisterEvent("QUEST_TURNED_IN", FindWorldQuestComplete)
+	K:RegisterEvent("UI_INFO_MESSAGE", FindQuestProgress)
 end


### PR DESCRIPTION
fix event registration

Issue Fixed #<not logged>

## Proposed Changes

  - replace self (not existing in that context) with K (globally existing frame) for event registration
  - when left as self, quest notifier won't work, since self == nil

@Kkthnx-WoW
