### PR TITLE
Fixed one click disenchant module rogue frame

### DIFF
--- a/KkthnxUI/Modules/Automation/Elements/Disenchant.lua
+++ b/KkthnxUI/Modules/Automation/Elements/Disenchant.lua
@@ -18,101 +18,102 @@ local IsSpellKnown = _G.IsSpellKnown
 local LE_ITEM_CLASS_ARMOR = _G.LE_ITEM_CLASS_ARMOR
 local LE_ITEM_CLASS_WEAPON = _G.LE_ITEM_CLASS_WEAPON
 
-local button = CreateFrame("Button", "KKUI_OneClickMPD", UIParent, "SecureActionButtonTemplate, AutoCastShineTemplate")
-button:SetScript("OnEvent", function(self, event, ...)
-	if not C["Automation"].AutoDisenchant then
-		return
-	end
+local button
+if C["Automation"].AutoDisenchant then
+	button = CreateFrame("Button", "KKUI_OneClickMPD", UIParent, "SecureActionButtonTemplate, AutoCastShineTemplate")
+	button:SetScript("OnEvent", function(self, event, ...)
 
 	self[event](self, ...)
-end)
-button:RegisterEvent("PLAYER_LOGIN")
-
-function button:PLAYER_LOGIN()
-	local milling, prospect, disenchanter, rogue
-
-	if IsSpellKnown(51005) then
-		milling = true
-	end
-
-	if IsSpellKnown(31252) then
-		prospect = true
-	end
-
-	if IsSpellKnown(13262) then
-		disenchanter = true
-	end
-
-	if IsSpellKnown(1804) then
-		rogue = ITEM_MIN_SKILL:gsub("%%s", (K.Client == "ruRU" and "Взлом замков" or GetSpellInfo(1809))):gsub("%%d", "%(.*%)")
-	end
-
-	GameTooltip:HookScript("OnTooltipSetItem", function(self)
-		local _, link = self:GetItem()
-		if link and not InCombatLockdown() and IsAltKeyDown() and not (AuctionFrame and AuctionFrame:IsShown()) then
-			local itemID = GetItemInfoFromHyperlink(link)
-			if not itemID then
-				return
-			end
-			local spell, r, g, b
-			if milling and GetItemCount(itemID) >= 5 and C.MPDHerbs[itemID] then
-				spell, r, g, b = GetSpellInfo(51005), 0.5, 1, 0.5
-			elseif prospect and GetItemCount(itemID) >= 5 and C.MPDOres[itemID] then
-				spell, r, g, b = GetSpellInfo(31252), 1, 0.33, 0.33
-			elseif disenchanter then
-				local _, _, itemRarity, _, _, _, _, _, _, _, _, class, subClass = GetItemInfo(link)
-				if not (class == LE_ITEM_CLASS_WEAPON or class == LE_ITEM_CLASS_ARMOR or (class == 3 and subClass == 11)) or not (itemRarity and (itemRarity > 1 and (itemRarity < 5 or itemRarity == 6))) then
+	end)
+	
+	button:RegisterEvent("PLAYER_LOGIN")
+	
+	function button:PLAYER_LOGIN()
+		local milling, prospect, disenchanter, rogue
+		
+		if IsSpellKnown(51005) then
+			milling = true
+		end
+		
+		if IsSpellKnown(31252) then
+			prospect = true
+		end
+		
+		if IsSpellKnown(13262) then
+			disenchanter = true
+		end
+		
+		if IsSpellKnown(1804) then
+			rogue = ITEM_MIN_SKILL:gsub("%%s", (K.Client == "ruRU" and "Взлом замков" or GetSpellInfo(1809))):gsub("%%d", "%(.*%)")
+		end
+		
+		GameTooltip:HookScript("OnTooltipSetItem", function(self)
+			local _, link = self:GetItem()
+			if link and not InCombatLockdown() and IsAltKeyDown() and not (AuctionFrame and AuctionFrame:IsShown()) then
+				local itemID = GetItemInfoFromHyperlink(link)
+				if not itemID then
 					return
 				end
-				spell, r, g, b = GetSpellInfo(13262), 0.5, 0.5, 1
-			elseif rogue then
-				for index = 1, self:NumLines() do
-					if string_match(_G["GameTooltipTextLeft"..index]:GetText() or "", rogue) then
-						spell, r, g, b = GetSpellInfo(1804), 0, 1, 1
+				local spell, r, g, b
+				if milling and GetItemCount(itemID) >= 5 and C.MPDHerbs[itemID] then
+					spell, r, g, b = GetSpellInfo(51005), 0.5, 1, 0.5
+				elseif prospect and GetItemCount(itemID) >= 5 and C.MPDOres[itemID] then
+					spell, r, g, b = GetSpellInfo(31252), 1, 0.33, 0.33
+				elseif disenchanter then
+					local _, _, itemRarity, _, _, _, _, _, _, _, _, class, subClass = GetItemInfo(link)
+					if not (class == LE_ITEM_CLASS_WEAPON or class == LE_ITEM_CLASS_ARMOR or (class == 3 and subClass == 11)) or not (itemRarity and (itemRarity > 1 and (itemRarity < 5 or itemRarity == 6))) then
+						return
+					end
+					spell, r, g, b = GetSpellInfo(13262), 0.5, 0.5, 1
+				elseif rogue then
+					for index = 1, self:NumLines() do
+						if string_match(_G["GameTooltipTextLeft"..index]:GetText() or "", rogue) then
+							spell, r, g, b = GetSpellInfo(1804), 0, 1, 1
+						end
 					end
 				end
+				
+				local bag, slot = GetMouseFocus():GetParent(), GetMouseFocus()
+				if spell and GetContainerItemLink(bag:GetID(), slot:GetID()) == link then
+					button:SetAttribute("macrotext", string_format("/cast %s\n/use %s %s", spell, bag:GetID(), slot:GetID()))
+					button:SetAllPoints(slot)
+					button:Show()
+					AutoCastShine_AutoCastStart(button, r, g, b)
+				end
 			end
-
-			local bag, slot = GetMouseFocus():GetParent(), GetMouseFocus()
-			if spell and GetContainerItemLink(bag:GetID(), slot:GetID()) == link then
-				button:SetAttribute("macrotext", string_format("/cast %s\n/use %s %s", spell, bag:GetID(), slot:GetID()))
-				button:SetAllPoints(slot)
-				button:Show()
-				AutoCastShine_AutoCastStart(button, r, g, b)
-			end
-		end
-	end)
-
-	self:SetFrameStrata("TOOLTIP")
-	self:SetAttribute("*type1", "macro")
-	self:SetScript("OnLeave", self.MODIFIER_STATE_CHANGED)
-
-	self:RegisterEvent("MODIFIER_STATE_CHANGED")
-	self:Hide()
-
-	for _, sparks in pairs(self.sparkles) do
-		sparks:SetHeight(sparks:GetHeight() * 3)
-		sparks:SetWidth(sparks:GetWidth() * 3)
-	end
-end
-
-function button:MODIFIER_STATE_CHANGED(key)
-	if not self:IsShown() and not key and key ~= "LALT" and key ~= "RALT" then
-		return
-	end
-
-	if InCombatLockdown() then
-		self:SetAlpha(0)
-		self:RegisterEvent("PLAYER_REGEN_ENABLED")
-	else
-		self:ClearAllPoints()
-		self:SetAlpha(1)
+		end)
+		
+		self:SetFrameStrata("TOOLTIP")
+		self:SetAttribute("*type1", "macro")
+		self:SetScript("OnLeave", self.MODIFIER_STATE_CHANGED)
+		
+		self:RegisterEvent("MODIFIER_STATE_CHANGED")
 		self:Hide()
-		AutoCastShine_AutoCastStop(self)
+		
+		for _, sparks in pairs(self.sparkles) do
+			sparks:SetHeight(sparks:GetHeight() * 3)
+			sparks:SetWidth(sparks:GetWidth() * 3)
+		end
 	end
-end
-
-function button:PLAYER_REGEN_ENABLED()
-	self:UnregisterEvent("PLAYER_REGEN_ENABLED")
-	self:MODIFIER_STATE_CHANGED()
+	
+	function button:MODIFIER_STATE_CHANGED(key)
+		if not self:IsShown() and not key and key ~= "LALT" and key ~= "RALT" then
+			return
+		end
+		
+		if InCombatLockdown() then
+			self:SetAlpha(0)
+			self:RegisterEvent("PLAYER_REGEN_ENABLED")
+		else
+			self:ClearAllPoints()
+			self:SetAlpha(1)
+			self:Hide()
+			AutoCastShine_AutoCastStop(self)
+		end
+	end
+	
+	function button:PLAYER_REGEN_ENABLED()
+		self:UnregisterEvent("PLAYER_REGEN_ENABLED")
+		self:MODIFIER_STATE_CHANGED()
+	end
 end

--- a/KkthnxUI/Modules/Automation/Elements/Disenchant.lua
+++ b/KkthnxUI/Modules/Automation/Elements/Disenchant.lua
@@ -26,6 +26,11 @@ button:SetScript("OnEvent", function(self, event, ...)
 
 	self[event](self, ...)
 end)
+
+if not C["Automation"].AutoDisenchant then
+	button:EnableMouse(false)
+end
+
 button:RegisterEvent("PLAYER_LOGIN")
 
 function button:PLAYER_LOGIN()

--- a/KkthnxUI/Modules/Automation/Elements/Disenchant.lua
+++ b/KkthnxUI/Modules/Automation/Elements/Disenchant.lua
@@ -18,13 +18,13 @@ local IsSpellKnown = _G.IsSpellKnown
 local LE_ITEM_CLASS_ARMOR = _G.LE_ITEM_CLASS_ARMOR
 local LE_ITEM_CLASS_WEAPON = _G.LE_ITEM_CLASS_WEAPON
 
-local button
-if C["Automation"].AutoDisenchant then
-	button = CreateFrame("Button", "KKUI_OneClickMPD", UIParent, "SecureActionButtonTemplate, AutoCastShineTemplate")
-	button:SetScript("OnEvent", function(self, event, ...)
+local button = CreateFrame("Button", "KKUI_OneClickMPD", UIParent, "SecureActionButtonTemplate, AutoCastShineTemplate")
+button:SetScript("OnEvent", function(self, event, ...)
+	if not C["Automation"].AutoDisenchant then
+		return
+	end
 
 	self[event](self, ...)
-<<<<<<< HEAD
 end)
 
 if not C["Automation"].AutoDisenchant then
@@ -67,98 +67,57 @@ function button:PLAYER_LOGIN()
 			elseif disenchanter then
 				local _, _, itemRarity, _, _, _, _, _, _, _, _, class, subClass = GetItemInfo(link)
 				if not (class == LE_ITEM_CLASS_WEAPON or class == LE_ITEM_CLASS_ARMOR or (class == 3 and subClass == 11)) or not (itemRarity and (itemRarity > 1 and (itemRarity < 5 or itemRarity == 6))) then
-=======
-	end)
-	
-	button:RegisterEvent("PLAYER_LOGIN")
-	
-	function button:PLAYER_LOGIN()
-		local milling, prospect, disenchanter, rogue
-		
-		if IsSpellKnown(51005) then
-			milling = true
-		end
-		
-		if IsSpellKnown(31252) then
-			prospect = true
-		end
-		
-		if IsSpellKnown(13262) then
-			disenchanter = true
-		end
-		
-		if IsSpellKnown(1804) then
-			rogue = ITEM_MIN_SKILL:gsub("%%s", (K.Client == "ruRU" and "Взлом замков" or GetSpellInfo(1809))):gsub("%%d", "%(.*%)")
-		end
-		
-		GameTooltip:HookScript("OnTooltipSetItem", function(self)
-			local _, link = self:GetItem()
-			if link and not InCombatLockdown() and IsAltKeyDown() and not (AuctionFrame and AuctionFrame:IsShown()) then
-				local itemID = GetItemInfoFromHyperlink(link)
-				if not itemID then
->>>>>>> 47a85899b88db724dbe525fa78c9779f454ac2d7
 					return
 				end
-				local spell, r, g, b
-				if milling and GetItemCount(itemID) >= 5 and C.MPDHerbs[itemID] then
-					spell, r, g, b = GetSpellInfo(51005), 0.5, 1, 0.5
-				elseif prospect and GetItemCount(itemID) >= 5 and C.MPDOres[itemID] then
-					spell, r, g, b = GetSpellInfo(31252), 1, 0.33, 0.33
-				elseif disenchanter then
-					local _, _, itemRarity, _, _, _, _, _, _, _, _, class, subClass = GetItemInfo(link)
-					if not (class == LE_ITEM_CLASS_WEAPON or class == LE_ITEM_CLASS_ARMOR or (class == 3 and subClass == 11)) or not (itemRarity and (itemRarity > 1 and (itemRarity < 5 or itemRarity == 6))) then
-						return
+				spell, r, g, b = GetSpellInfo(13262), 0.5, 0.5, 1
+			elseif rogue then
+				for index = 1, self:NumLines() do
+					if string_match(_G["GameTooltipTextLeft"..index]:GetText() or "", rogue) then
+						spell, r, g, b = GetSpellInfo(1804), 0, 1, 1
 					end
-					spell, r, g, b = GetSpellInfo(13262), 0.5, 0.5, 1
-				elseif rogue then
-					for index = 1, self:NumLines() do
-						if string_match(_G["GameTooltipTextLeft"..index]:GetText() or "", rogue) then
-							spell, r, g, b = GetSpellInfo(1804), 0, 1, 1
-						end
-					end
-				end
-				
-				local bag, slot = GetMouseFocus():GetParent(), GetMouseFocus()
-				if spell and GetContainerItemLink(bag:GetID(), slot:GetID()) == link then
-					button:SetAttribute("macrotext", string_format("/cast %s\n/use %s %s", spell, bag:GetID(), slot:GetID()))
-					button:SetAllPoints(slot)
-					button:Show()
-					AutoCastShine_AutoCastStart(button, r, g, b)
 				end
 			end
-		end)
-		
-		self:SetFrameStrata("TOOLTIP")
-		self:SetAttribute("*type1", "macro")
-		self:SetScript("OnLeave", self.MODIFIER_STATE_CHANGED)
-		
-		self:RegisterEvent("MODIFIER_STATE_CHANGED")
+
+			local bag, slot = GetMouseFocus():GetParent(), GetMouseFocus()
+			if spell and GetContainerItemLink(bag:GetID(), slot:GetID()) == link then
+				button:SetAttribute("macrotext", string_format("/cast %s\n/use %s %s", spell, bag:GetID(), slot:GetID()))
+				button:SetAllPoints(slot)
+				button:Show()
+				AutoCastShine_AutoCastStart(button, r, g, b)
+			end
+		end
+	end)
+
+	self:SetFrameStrata("TOOLTIP")
+	self:SetAttribute("*type1", "macro")
+	self:SetScript("OnLeave", self.MODIFIER_STATE_CHANGED)
+
+	self:RegisterEvent("MODIFIER_STATE_CHANGED")
+	self:Hide()
+
+	for _, sparks in pairs(self.sparkles) do
+		sparks:SetHeight(sparks:GetHeight() * 3)
+		sparks:SetWidth(sparks:GetWidth() * 3)
+	end
+end
+
+function button:MODIFIER_STATE_CHANGED(key)
+	if not self:IsShown() and not key and key ~= "LALT" and key ~= "RALT" then
+		return
+	end
+
+	if InCombatLockdown() then
+		self:SetAlpha(0)
+		self:RegisterEvent("PLAYER_REGEN_ENABLED")
+	else
+		self:ClearAllPoints()
+		self:SetAlpha(1)
 		self:Hide()
-		
-		for _, sparks in pairs(self.sparkles) do
-			sparks:SetHeight(sparks:GetHeight() * 3)
-			sparks:SetWidth(sparks:GetWidth() * 3)
-		end
+		AutoCastShine_AutoCastStop(self)
 	end
-	
-	function button:MODIFIER_STATE_CHANGED(key)
-		if not self:IsShown() and not key and key ~= "LALT" and key ~= "RALT" then
-			return
-		end
-		
-		if InCombatLockdown() then
-			self:SetAlpha(0)
-			self:RegisterEvent("PLAYER_REGEN_ENABLED")
-		else
-			self:ClearAllPoints()
-			self:SetAlpha(1)
-			self:Hide()
-			AutoCastShine_AutoCastStop(self)
-		end
-	end
-	
-	function button:PLAYER_REGEN_ENABLED()
-		self:UnregisterEvent("PLAYER_REGEN_ENABLED")
-		self:MODIFIER_STATE_CHANGED()
-	end
+end
+
+function button:PLAYER_REGEN_ENABLED()
+	self:UnregisterEvent("PLAYER_REGEN_ENABLED")
+	self:MODIFIER_STATE_CHANGED()
 end


### PR DESCRIPTION
Fixed the issue where disabling the one click DE module would still generate the frame, but anchor it to the middle of the screen cause it has nowhere to go. It does still generate the frame, but I've disabled mouse input on it.

Initial solution where I only created the frame with the module enabled didn't work as intended, and behavior seemed unpredictable, I might take another look at a "proper" fix some other time, but for now this change does address the issue.