### PR TITLE
fix backdrop err msg

### DIFF
--- a/KkthnxUI/Modules/Skins/Blizzard/ChatFrame.lua
+++ b/KkthnxUI/Modules/Skins/Blizzard/ChatFrame.lua
@@ -8,13 +8,8 @@ local hooksecurefunc = _G.hooksecurefunc
 table_insert(C.defaultThemes, function()
 	-- Battlenet toast frame
 	BNToastFrame:SetClampedToScreen(true)
-	BNToastFrame:SetBackdrop(nil)
 	BNToastFrame:CreateBorder()
-	if K.IsNewPatch then
-		BNToastFrame.TooltipFrame.NineSlice:SetAlpha(0)
-	else
-		BNToastFrame.TooltipFrame:SetBackdrop(nil)
-	end
+	BNToastFrame.TooltipFrame.NineSlice:SetAlpha(0)
 	BNToastFrame.TooltipFrame:CreateBorder()
 	BNToastFrame.CloseButton:SkinCloseButton()
 	BNToastFrame.CloseButton:SetSize(32, 32)

--- a/KkthnxUI/Modules/Tooltip/Core.lua
+++ b/KkthnxUI/Modules/Tooltip/Core.lua
@@ -558,7 +558,6 @@ function Module:SharedTooltip_SetBackdropStyle()
 		return
 	end
 
-	self:SetBackdrop(nil)
 end
 
 function Module:OnEnable()


### PR DESCRIPTION
removes spamming lua err msg. 

--------------------------------------------------

_TODO_

- The backdrop API has been moved to [BackdropTemplate](https://wowpedia.fandom.com/wiki/BackdropTemplate)